### PR TITLE
testiso: handle test patterns like `kola run` and exit nonzero if at least one test failed

### DIFF
--- a/mantle/cmd/kola/testiso.go
+++ b/mantle/cmd/kola/testiso.go
@@ -472,6 +472,7 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 
 	var duration time.Duration
 
+	atLeastOneFailed := false
 	for _, test := range finalTests {
 
 		// All of these tests require buildextend-live to have been run
@@ -523,7 +524,13 @@ func runTestIso(cmd *cobra.Command, args []string) error {
 		default:
 			plog.Fatalf("Unknown test name:%s", test)
 		}
-		printResult(test, duration, err)
+		if printResult(test, duration, err) {
+			atLeastOneFailed = true
+		}
+	}
+
+	if atLeastOneFailed {
+		return harness.SuiteFailed
 	}
 
 	return nil


### PR DESCRIPTION
Drop the `--tests` flag in favour of positional arguments. Treat these
args as patterns like we do in `kola run` and filter from the full list
of tests. Drop the global variables.

---

Match the semantics of `kola run` of exiting non-zero if at least one
test failed.